### PR TITLE
fix(url): update url to stop curl 403

### DIFF
--- a/scripts/rexray-scaleio.sh
+++ b/scripts/rexray-scaleio.sh
@@ -1,4 +1,4 @@
-curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -s -- stable
+curl -sSL https://rexray.io/install | sh -s -- stable
 cat << EOF > /etc/rexray/config.yml
 libstorage:
   service: scaleio

--- a/scripts/rexray-vbox.sh
+++ b/scripts/rexray-vbox.sh
@@ -1,4 +1,4 @@
-curl -sSL https://dl.bintray.com/emccode/rexray/install | sh -s -- stable
+curl -sSL https://rexray.io/install | sh -s -- stable
 cat << EOF > /etc/rexray/config.yml
 libstorage:
   service: virtualbox


### PR DESCRIPTION
The URL (https://dl.bintray.com/emccode/rexray/install) returns 403.  Updated URL